### PR TITLE
Greedy sol comparison

### DIFF
--- a/Assignment6.java
+++ b/Assignment6.java
@@ -52,9 +52,10 @@ public class Assignment6 {
      *
      * @param given   initial version of the array of numbers.
      * @param desired final version of the array of numbers.
+     * @param alg algorithm used in the unblock case
      * @return list of moves made during arrangement.
      */
-    public static List<Move> rearrangeGreedy(int[] given, int[] desired) {
+    public static List<Move> rearrangeGreedy(int[] given, int[] desired, GREEDY_ALG_TYPE alg) {
         List<Move> listOfMoves = new LinkedList<>();
         
         // Keys are values in given, values are their indexes in given.
@@ -63,8 +64,8 @@ public class Assignment6 {
         // All cars are initially candidates
         HashSet<Integer> misplacedCars = populateMisplacedCars(given, desired);
 
-        for (int car = nextCarToMove(given, desired, indexMap, misplacedCars); car > 0;
-                car = nextCarToMove(given, desired, indexMap, misplacedCars)) {
+        for (int car = nextCarToMove(given, desired, indexMap, misplacedCars, alg); car > 0;
+                car = nextCarToMove(given, desired, indexMap, misplacedCars, alg)) {
             listOfMoves.add(move(car, given, indexMap));
         }
         
@@ -80,7 +81,7 @@ public class Assignment6 {
      * @param indexMap the map from cars to slots
      * @return next car to be moved (0 in case of rearranged array)
      */
-    private static int nextCarToMove(int[] given, int[] desired, Map<Integer, Integer> indexMap, HashSet<Integer> misplacedCars) {
+    private static int nextCarToMove(int[] given, int[] desired, Map<Integer, Integer> indexMap, HashSet<Integer> misplacedCars, GREEDY_ALG_TYPE alg) {
         //arrays of length 0
         if (given.length == 0) {
             return 0;
@@ -95,13 +96,33 @@ public class Assignment6 {
 
         }
 
-        //empty lot in its desired place => deblock the algorithm
+        //empty lot in its desired place => unblock the algorithm
+        switch (alg) {
+            case UNBLOCK_USING_SET:
+                return unblockUsingMisplacedCar(misplacedCars);
+            case UNBLOCK_USING_TRAVERSAL:
+                return unblockUsingTraversal(given, desired);
+        }
+
+        //given array is rearranged
+        return 0;
+    }
+
+    private static int unblockUsingTraversal(int[] given, int[] desired) {
+        //find the first car that isn't in its right place
+        for (int i = 0; i < given.length; i++) {
+            if (given[i] != 0 && given[i] != desired[i]) {
+                return given[i];
+            }
+        }
+        return 0;
+    }
+
+    private static int unblockUsingMisplacedCar(HashSet<Integer> misplacedCars) {
         // pick a random car from set of misplaced cars
         if (misplacedCars.size() > 0) {
             return misplacedCars.iterator().next();
         }
-
-        //given array is rearranged
         return 0;
     }
 
@@ -172,6 +193,11 @@ public class Assignment6 {
      */
     private static void printMove(Move m) {
         System.out.println(m.toString());
+    }
+
+    public enum GREEDY_ALG_TYPE {
+        UNBLOCK_USING_TRAVERSAL,
+        UNBLOCK_USING_SET
     }
     
 }

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -1,4 +1,3 @@
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -12,15 +11,11 @@ public class Assignment6 {
      * @param desired final version of the array of numbers.
      * @return list of moves made during arrangement.
      */
-    public static List<List<Integer>> rearrange(int[] given, int[] desired) {
+    public static List<Move> rearrange(int[] given, int[] desired) {
+        List<Move> listOfMoves = new LinkedList<>();
+        
         // Keys are values in given, values are their indexes in given.
-        Map<Integer, Integer> indexMap = new HashMap<>();
-        // Generated for testing purposes.
-        List<List<Integer>> listOfMoves = new LinkedList<>();
-
-        for (int i = 0; i < given.length; i++) {
-            indexMap.put(given[i], i);
-        }
+        Map<Integer, Integer> indexMap = populateIndexMap(given);
 
         for (int i = 0; i < desired.length; i++) {
             // Already in its desired place.
@@ -28,48 +23,79 @@ public class Assignment6 {
                 continue;
             }
 
-            int indexOf0 = indexMap.get(0);
-
+            // i should be the empty slot
+            if (desired[i] == 0) {
+                continue;
+            }
+            
             // If i isn't already empty.
-            if (indexOf0 != i) {
+            if (indexMap.get(0) != i) {
                 // Move the number in i to the empty slot so that i becomes empty.
-                indexMap.put(0, i);
-                indexMap.put(given[i], indexOf0);
-
-                given[indexOf0] = given[i];
-                given[i] = 0;
-
-                printMove(i, indexOf0);
-
-                List<Integer> moves = Arrays.asList(i, indexOf0);
-                listOfMoves.add(moves);
+                Move emptyCurrentSlot = new Move(given[i], i, indexMap.get(0));
+                
+                listOfMoves.add(emptyCurrentSlot);
+                move(emptyCurrentSlot, given, indexMap);
             }
 
-            int indexOfDesiredInGiven = indexMap.get(desired[i]);
-
             // Move the desired number to i.
-            indexMap.put(0, indexOfDesiredInGiven);
-            indexMap.put(desired[i], i);
+            Move moveToCurrentSlot = new Move(given[indexMap.get(desired[i])], indexMap.get(desired[i]), i);
 
-            given[indexOfDesiredInGiven] = 0;
-            given[i] = desired[i];
-
-            printMove(indexOfDesiredInGiven, i);
-
-            List<Integer> moves = Arrays.asList(indexOfDesiredInGiven, i);
-            listOfMoves.add(moves);
+            listOfMoves.add(moveToCurrentSlot);
+            move(moveToCurrentSlot, given, indexMap);
         }
 
         return listOfMoves;
     }
 
     /**
-     * Prints the move.
-     * @param from index the move is made from.
-     * @param to index the move is made to.
+     * Executes a move both on the parking lot array and on the indexMap of the
+     * cars.
+     *
+     * @param m the move to be executed
+     * @param map the array (map) of the parking lot
+     * @param indexMap the map from cars to slots
      */
-    private static void printMove(int from, int to) {
-        System.out.printf("move from %d to %d", from, to);
+    private static void move(Move m, int[] map, Map<Integer, Integer> indexMap) {
+        indexMap.put(0, m.getFrom());
+        indexMap.put(m.getCar(), m.getTo());
+
+        map[m.getFrom()] = 0;
+        map[m.getTo()] = m.getCar();
+    }
+    
+    /**
+     * Creates a map from car to slot.
+     * 
+     * @param map the array (map) of the parking lot
+     * @return the map from cars to slots
+     */
+    private static Map<Integer, Integer> populateIndexMap(int[] map) {
+        Map<Integer, Integer> indexMap = new HashMap<>();
+        for (int i = 0; i < map.length; i++) {
+            indexMap.put(map[i], i);
+        }
+        return indexMap;
+    }
+    
+    /**
+     * Prints a list of moves.
+     *
+     * @param plan list of moves
+     */
+    public static void printListOfMoves(List<Move> plan) {
+        plan.forEach((m) -> {
+            printMove(m);
+        });
+    }
+    
+    /**
+     * Prints the move.
+     * 
+     * @param m the move
+     */
+    private static void printMove(Move m) {
+        System.out.printf("car %d moves from %d to %d", m.getCar(), m.getFrom(), m.getTo());
         System.out.println();
     }
+    
 }

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -1,3 +1,5 @@
+package assignment6;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -6,6 +8,7 @@ import java.util.Map;
 public class Assignment6 {
     /**
      * Rearranges given to make it the same as desired.
+     * O(n) time complexity, O(n) space complexity.
      *
      * @param given   initial version of the array of numbers.
      * @param desired final version of the array of numbers.
@@ -31,36 +34,87 @@ public class Assignment6 {
             // If i isn't already empty.
             if (indexMap.get(0) != i) {
                 // Move the number in i to the empty slot so that i becomes empty.
-                Move emptyCurrentSlot = new Move(given[i], i, indexMap.get(0));
-                
-                listOfMoves.add(emptyCurrentSlot);
-                move(emptyCurrentSlot, given, indexMap);
+                listOfMoves.add(move(given[i], given, indexMap));
             }
 
             // Move the desired number to i.
-            Move moveToCurrentSlot = new Move(given[indexMap.get(desired[i])], indexMap.get(desired[i]), i);
-
-            listOfMoves.add(moveToCurrentSlot);
-            move(moveToCurrentSlot, given, indexMap);
+            listOfMoves.add(move(desired[i], given, indexMap));
         }
 
         return listOfMoves;
+    }
+    
+    /**
+     * Rearranges given to make it the same as desired.
+     * Greedy algorithm to find the rearrangement with the least number of moves.
+     * O(n^2) worst case time complexity, O(n) space complexity.
+     *
+     * @param given   initial version of the array of numbers.
+     * @param desired final version of the array of numbers.
+     * @return list of moves made during arrangement.
+     */
+    public static List<Move> rearrangeGreedy(int[] given, int[] desired) {
+        List<Move> listOfMoves = new LinkedList<>();
+        
+        // Keys are values in given, values are their indexes in given.
+        Map<Integer, Integer> indexMap = populateIndexMap(given);
+
+        for (int car = nextCarToMove(given, desired, indexMap); car > 0;
+                car = nextCarToMove(given, desired, indexMap)) {
+            
+            listOfMoves.add(move(car, given, indexMap));
+        }
+        
+        return listOfMoves;
+    }
+    
+    /**
+     * Computes (greedily) the best choice of car to be moved next.
+     * O(n) worst case time complexity.
+     * 
+     * @param given    initial version of the array of numbers.
+     * @param desired  final version of the array of numbers.
+     * @param indexMap the map from cars to slots
+     * @return next car to be moved (0 in case of rearranged array)
+     */
+    private static int nextCarToMove(int[] given, int[] desired, Map<Integer, Integer> indexMap) {
+        //arrays of length 0
+        if (given.length == 0) {
+            return 0;
+        }
+        
+        //car belonging to the current empty slot
+        if (desired[indexMap.get(0)] != 0) {
+            return desired[indexMap.get(0)];
+        }
+        
+        //empty lot in its desired place => deblock the algorithm
+        //find the first car that isn't in its right place
+        for (int i = 0; i < given.length; i++) {
+            if (given[i] != 0 && given[i] != desired[i]) {
+                return given[i];
+            }
+        }
+        //given array is rearranged
+        return 0;
     }
 
     /**
      * Executes a move both on the parking lot array and on the indexMap of the
      * cars.
      *
-     * @param m the move to be executed
+     * @param car the car to be moved
      * @param map the array (map) of the parking lot
      * @param indexMap the map from cars to slots
      */
-    private static void move(Move m, int[] map, Map<Integer, Integer> indexMap) {
+    private static Move move(int car, int[] map, Map<Integer, Integer> indexMap) {
+        Move m = new Move(car, indexMap.get(car), indexMap.get(0));
         indexMap.put(0, m.getFrom());
         indexMap.put(m.getCar(), m.getTo());
 
         map[m.getFrom()] = 0;
         map[m.getTo()] = m.getCar();
+        return m;
     }
     
     /**
@@ -94,8 +148,7 @@ public class Assignment6 {
      * @param m the move
      */
     private static void printMove(Move m) {
-        System.out.printf("car %d moves from %d to %d", m.getCar(), m.getFrom(), m.getTo());
-        System.out.println();
+        System.out.println(m.toString());
     }
     
 }

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -1,9 +1,6 @@
 package assignment6;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Assignment6 {
     /**
@@ -59,8 +56,11 @@ public class Assignment6 {
         // Keys are values in given, values are their indexes in given.
         Map<Integer, Integer> indexMap = populateIndexMap(given);
 
-        for (int car = nextCarToMove(given, desired, indexMap); car > 0;
-                car = nextCarToMove(given, desired, indexMap)) {
+        // All cars are initially candidates
+        HashSet<Integer> misplacedCars = populateMisplacedCars(given, desired);
+
+        for (int car = nextCarToMove(given, desired, indexMap, misplacedCars); car > 0;
+                car = nextCarToMove(given, desired, indexMap, misplacedCars)) {
             
             listOfMoves.add(move(car, given, indexMap));
         }
@@ -77,7 +77,7 @@ public class Assignment6 {
      * @param indexMap the map from cars to slots
      * @return next car to be moved (0 in case of rearranged array)
      */
-    private static int nextCarToMove(int[] given, int[] desired, Map<Integer, Integer> indexMap) {
+    private static int nextCarToMove(int[] given, int[] desired, Map<Integer, Integer> indexMap, HashSet<Integer> misplacedCars) {
         //arrays of length 0
         if (given.length == 0) {
             return 0;
@@ -85,16 +85,20 @@ public class Assignment6 {
         
         //car belonging to the current empty slot
         if (desired[indexMap.get(0)] != 0) {
+            // car will be moved in place next, remove it from set of misplaced cars
+            misplacedCars.remove(desired[indexMap.get(0)]);
             return desired[indexMap.get(0)];
+
         }
-        
+
         //empty lot in its desired place => deblock the algorithm
-        //find the first car that isn't in its right place
-        for (int i = 0; i < given.length; i++) {
-            if (given[i] != 0 && given[i] != desired[i]) {
-                return given[i];
-            }
+        // pick a random car from set of misplaced cars
+        if (misplacedCars.size() > 0) {
+            Integer nextCarToMove = (Integer)misplacedCars.toArray()[0];
+            misplacedCars.remove(nextCarToMove);
+            return nextCarToMove;
         }
+
         //given array is rearranged
         return 0;
     }
@@ -129,6 +133,23 @@ public class Assignment6 {
             indexMap.put(map[i], i);
         }
         return indexMap;
+    }
+
+    /**
+     * Creates a hash set of misplaced cars comparing input and desired output.
+     *
+     * @param given the input array
+     * @param desired the output array
+     * @return the set of cars that are misplaced in the input array compared to the desired output.
+     */
+    private static HashSet<Integer> populateMisplacedCars(int[] given, int[] desired) {
+        HashSet<Integer> misplacedCars = new HashSet<Integer>();
+        for (int i = 0; i < given.length; i++) {
+            if (given[i] != desired[i] && given[i] != 0) {
+                misplacedCars.add(given[i]);
+            }
+        }
+        return misplacedCars;
     }
     
     /**

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -1,0 +1,75 @@
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class Assignment6 {
+    /**
+     * Rearranges given to make it the same as desired.
+     *
+     * @param given   initial version of the array of numbers.
+     * @param desired final version of the array of numbers.
+     * @return list of moves made during arrangement.
+     */
+    public static List<List<Integer>> rearrange(int[] given, int[] desired) {
+        // Keys are values in given, values are their indexes in given.
+        Map<Integer, Integer> indexMap = new HashMap<>();
+        // Generated for testing purposes.
+        List<List<Integer>> listOfMoves = new LinkedList<>();
+
+        for (int i = 0; i < given.length; i++) {
+            indexMap.put(given[i], i);
+        }
+
+        for (int i = 0; i < desired.length; i++) {
+            // Already in its desired place.
+            if (indexMap.get(desired[i]) == i) {
+                continue;
+            }
+
+            int indexOf0 = indexMap.get(0);
+
+            // If i isn't already empty.
+            if (indexOf0 != i) {
+                // Move the number in i to the empty slot so that i becomes empty.
+                indexMap.put(0, i);
+                indexMap.put(given[i], indexOf0);
+
+                given[indexOf0] = given[i];
+                given[i] = 0;
+
+                printMove(i, indexOf0);
+
+                List<Integer> moves = Arrays.asList(i, indexOf0);
+                listOfMoves.add(moves);
+            }
+
+            int indexOfDesiredInGiven = indexMap.get(desired[i]);
+
+            // Move the desired number to i.
+            indexMap.put(0, indexOfDesiredInGiven);
+            indexMap.put(desired[i], i);
+
+            given[indexOfDesiredInGiven] = 0;
+            given[i] = desired[i];
+
+            printMove(indexOfDesiredInGiven, i);
+
+            List<Integer> moves = Arrays.asList(indexOfDesiredInGiven, i);
+            listOfMoves.add(moves);
+        }
+
+        return listOfMoves;
+    }
+
+    /**
+     * Prints the move.
+     * @param from index the move is made from.
+     * @param to index the move is made to.
+     */
+    private static void printMove(int from, int to) {
+        System.out.printf("move from %d to %d", from, to);
+        System.out.println();
+    }
+}

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -97,7 +97,7 @@ public class Assignment6 {
         //empty lot in its desired place => deblock the algorithm
         // pick a random car from set of misplaced cars
         if (misplacedCars.size() > 0) {
-            Integer nextCarToMove = (Integer)misplacedCars.toArray()[0];
+            Integer nextCarToMove = misplacedCars.iterator().next();
             misplacedCars.remove(nextCarToMove);
             return nextCarToMove;
         }

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -1,6 +1,10 @@
 package assignment6;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashSet;
 
 public class Assignment6 {
     /**
@@ -61,8 +65,9 @@ public class Assignment6 {
 
         for (int car = nextCarToMove(given, desired, indexMap, misplacedCars); car > 0;
                 car = nextCarToMove(given, desired, indexMap, misplacedCars)) {
-            
             listOfMoves.add(move(car, given, indexMap));
+            // remove car from set of misplaced cars
+            misplacedCars.remove(car);
         }
         
         return listOfMoves;
@@ -85,8 +90,6 @@ public class Assignment6 {
         
         //car belonging to the current empty slot
         if (desired[indexMap.get(0)] != 0) {
-            // car will be moved in place next, remove it from set of misplaced cars
-            misplacedCars.remove(desired[indexMap.get(0)]);
             return desired[indexMap.get(0)];
 
         }

--- a/Assignment6.java
+++ b/Assignment6.java
@@ -66,8 +66,6 @@ public class Assignment6 {
         for (int car = nextCarToMove(given, desired, indexMap, misplacedCars); car > 0;
                 car = nextCarToMove(given, desired, indexMap, misplacedCars)) {
             listOfMoves.add(move(car, given, indexMap));
-            // remove car from set of misplaced cars
-            misplacedCars.remove(car);
         }
         
         return listOfMoves;
@@ -90,16 +88,17 @@ public class Assignment6 {
         
         //car belonging to the current empty slot
         if (desired[indexMap.get(0)] != 0) {
-            return desired[indexMap.get(0)];
+            // remove car from set of misplaced cars
+            int nextCarToMove = desired[indexMap.get(0)];
+            misplacedCars.remove(nextCarToMove);
+            return nextCarToMove;
 
         }
 
         //empty lot in its desired place => deblock the algorithm
         // pick a random car from set of misplaced cars
         if (misplacedCars.size() > 0) {
-            Integer nextCarToMove = misplacedCars.iterator().next();
-            misplacedCars.remove(nextCarToMove);
-            return nextCarToMove;
+            return misplacedCars.iterator().next();
         }
 
         //given array is rearranged
@@ -146,7 +145,7 @@ public class Assignment6 {
      * @return the set of cars that are misplaced in the input array compared to the desired output.
      */
     private static HashSet<Integer> populateMisplacedCars(int[] given, int[] desired) {
-        HashSet<Integer> misplacedCars = new HashSet<Integer>();
+        HashSet<Integer> misplacedCars = new HashSet<>();
         for (int i = 0; i < given.length; i++) {
             if (given[i] != desired[i] && given[i] != 0) {
                 misplacedCars.add(given[i]);

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -1,0 +1,56 @@
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.elifguler.Assignment6.rearrange;
+import static org.junit.jupiter.api.Assertions.*;
+
+class Assignment6Test {
+    @Test
+    void rearrangeTestNormal() {
+        int[] given = {1,2,0,3};
+        int[] desired = {3,1,2,0};
+
+        List<List<Integer>> list = rearrange(given, desired);
+        assertEquals(list, Arrays.asList(
+                Arrays.asList(0,2),
+                Arrays.asList(3,0),
+                Arrays.asList(1,3),
+                Arrays.asList(2,1),
+                Arrays.asList(3,2)
+        ));
+    }
+
+    @Test
+    void rearrangeTestArranged() {
+        int[] given = {1,2,0,3};
+        int[] desired = {1,2,0,3};
+
+        List<List<Integer>> list = rearrange(given, desired);
+        assertEquals(list, Collections.emptyList());
+    }
+
+    @Test
+    void rearrangeTestEmpty() {
+        int[] given = {};
+        int[] desired = {};
+
+        List<List<Integer>> list = rearrange(given, desired);
+        assertEquals(list, Collections.emptyList());
+    }
+
+    @Test
+    void rearrangeTestShift() {
+        int[] given = {0,1,2,3};
+        int[] desired = {1,2,3,0};
+
+        List<List<Integer>> list = rearrange(given, desired);
+        assertEquals(list, Arrays.asList(
+                Arrays.asList(1,0),
+                Arrays.asList(2,1),
+                Arrays.asList(3,2)
+        ));
+    }
+}

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -1,18 +1,30 @@
 package assignment6;
 
-import org.junit.jupiter.api.Test;
-
-import static assignment6.Assignment6.printListOfMoves;
 import static assignment6.Assignment6.rearrange;
 import static assignment6.Assignment6.rearrangeGreedy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class Assignment6Test {
 
+    /**
+     * Executes a plan (list of movements) on an arrangements of cars.
+     *
+     * @param given current map of the parking lot
+     * @param plan list of movements to be executed on the parking lot
+     */
+    public static void executeMoves(int[] given, List<Move> plan) {
+        plan.forEach((m) -> {
+            given[m.getTo()] = m.getCar();
+            given[m.getFrom()] = 0;
+        });
+    }
+    
     @Test
     public void rearrangeTestNormal() {
         int[] given = {1, 2, 0, 3};
@@ -79,9 +91,6 @@ public class Assignment6Test {
         int[] desired = {3, 1, 2, 0};
 
         List<Move> list = rearrangeGreedy(given, desired);
-
-        printListOfMoves(list);
-
         assertEquals(list, Arrays.asList(
                 new Move(2, 1, 2),
                 new Move(1, 0, 1),
@@ -142,4 +151,61 @@ public class Assignment6Test {
         assertEquals(list.size(), 7);
     }
     
+    @Test
+    public void testRearrangeRandom() {
+        ArrayList<Integer> givenList = new ArrayList<>();
+        ArrayList<Integer> desiredList = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            givenList.add(i);
+            desiredList.add(i);
+        }
+        java.util.Collections.shuffle(givenList);
+        java.util.Collections.shuffle(desiredList);
+        int[] given = givenList.stream().mapToInt(i->i).toArray();
+        int[] givenEx = given.clone();
+        int[] desired = desiredList.stream().mapToInt(i->i).toArray();
+        List<Move> list = rearrange(given, desired);
+        executeMoves(givenEx, list);
+        
+        assertArrayEquals(given, desired);
+    }
+    
+    
+    @Test
+    public void testRearrangeGreedyRandom() {
+        ArrayList<Integer> givenList = new ArrayList<>();
+        ArrayList<Integer> desiredList = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            givenList.add(i);
+            desiredList.add(i);
+        }
+        java.util.Collections.shuffle(givenList);
+        java.util.Collections.shuffle(desiredList);
+        int[] given = givenList.stream().mapToInt(i->i).toArray();
+        int[] givenEx = given.clone();
+        int[] desired = desiredList.stream().mapToInt(i->i).toArray();
+        List<Move> list = rearrangeGreedy(given, desired);
+        executeMoves(givenEx, list);
+        
+        assertArrayEquals(givenEx, desired);
+    }
+
+    @Test
+    public void testCompareNoOfMoves() {
+        ArrayList<Integer> givenList = new ArrayList<>();
+        ArrayList<Integer> desiredList = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            givenList.add(i);
+            desiredList.add(i);
+        }
+        java.util.Collections.shuffle(givenList);
+        java.util.Collections.shuffle(desiredList);
+        int[] given = givenList.stream().mapToInt(i -> i).toArray();
+        int[] givenGreedy = given.clone();
+        int[] desired = desiredList.stream().mapToInt(i -> i).toArray();
+        List<Move> list = rearrange(given, desired);
+        List<Move> listGreedy = rearrangeGreedy(givenGreedy, desired);
+
+        assert(list.size() >= listGreedy.size());
+    }
 }

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -214,33 +214,36 @@ public class Assignment6Test {
 
     @Test
     public void testStressCompareTimeAlmostInPlace() {
-        int[] given = new int[100000];
-        int[] desired = new int[100000];
+        int[] givenSet = new int[100000];
+        int[] desiredSet = new int[100000];
         for (int i = 0; i < 100000; i++) {
-            given[i] = i;
-            desired[i] = i;
+            givenSet[i] = i;
+            desiredSet[i] = i;
         }
-        desired[90000] = 90003;
-        desired[90001] = 90000;
-        desired[90002] = 90001;
-        desired[90003] = 90002;
+        desiredSet[90000] = 90003;
+        desiredSet[90001] = 90000;
+        desiredSet[90002] = 90001;
+        desiredSet[90003] = 90002;
 
-        // warm up cache to avoid one alg being handicapped by cache misses
-        rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
+        int[] givenTraversal = givenSet.clone();
+        int[] desiredTraversal = desiredSet.clone();
 
         //measure
         long start = System.nanoTime();
-        List<Move> movesCaseTraversal = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
+        List<Move> movesCaseTraversal = rearrangeGreedy(givenTraversal, desiredTraversal, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
         long end = System.nanoTime();
         long timeTraversalNano = end - start;
 
         start = System.nanoTime();
-        List<Move> movesCaseSet = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> movesCaseSet = rearrangeGreedy(givenSet, desiredSet, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         end = System.nanoTime();
         long timeSetNano = end - start;
 
         System.out.println(timeSetNano);
         System.out.println(timeTraversalNano);
+
+        System.out.println(movesCaseSet.size());
+        System.out.println(movesCaseTraversal.size());
 
         assert(movesCaseSet.size() <= movesCaseTraversal.size());
         assert(timeSetNano <= timeTraversalNano);

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -1,20 +1,21 @@
 package assignment6;
 
-import static assignment6.Assignment6.rearrange;
-import static assignment6.Assignment6.rearrangeGreedy;
-import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static assignment6.Assignment6.rearrange;
+import static assignment6.Assignment6.rearrangeGreedy;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class Assignment6Test {
-
+    private int[] given;
+    private int[] desired;
     /**
      * Executes a plan (list of movements) on an arrangements of cars.
      *
@@ -27,10 +28,14 @@ public class Assignment6Test {
             given[m.getFrom()] = 0;
         });
     }
-    
+
+    @Before
+    public void setUp() {
+        given = new int[]{1, 2, 0, 3};
+        desired = new int[]{0, 1, 3, 2};
+    }
     @Test
     public void rearrangeTestNormal() {
-        int[] given = {1, 2, 0, 3};
         int[] desired = {3, 1, 2, 0};
 
         List<Move> list = rearrange(given, desired);
@@ -45,9 +50,6 @@ public class Assignment6Test {
 
     @Test
     public void rearrangeTestMoveEmpty() {
-        int[] given = {1, 2, 0, 3};
-        int[] desired = {0, 1, 3, 2};
-        
         List<Move> list = rearrange(given, desired);
         assertEquals(list, Arrays.asList(
                 new Move(2, 1, 2),
@@ -59,7 +61,6 @@ public class Assignment6Test {
     
     @Test
     public void rearrangeTestArranged() {
-        int[] given = {1, 2, 0, 3};
         int[] desired = {1, 2, 0, 3};
 
         List<Move> list = rearrange(given, desired);
@@ -90,10 +91,9 @@ public class Assignment6Test {
     
     @Test
     public void rearrangeGreedyTestNormal() {
-        int[] given = {1, 2, 0, 3};
         int[] desired = {3, 1, 2, 0};
 
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         assertEquals(list, Arrays.asList(
                 new Move(2, 1, 2),
                 new Move(1, 0, 1),
@@ -103,10 +103,7 @@ public class Assignment6Test {
 
     @Test
     public void rearrangeGreedyTestMoveEmpty() {
-        int[] given = {1, 2, 0, 3};
-        int[] desired = {0, 1, 3, 2};
-        
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         assertEquals(list, Arrays.asList(
                 new Move(3, 3, 2),
                 new Move(2, 1, 3),
@@ -115,10 +112,9 @@ public class Assignment6Test {
     
     @Test
     public void rearrangeGreedyTestArranged() {
-        int[] given = {1, 2, 0, 3};
         int[] desired = {1, 2, 0, 3};
 
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         assertEquals(list, Collections.emptyList());
     }
 
@@ -127,7 +123,7 @@ public class Assignment6Test {
         int[] given = {};
         int[] desired = {};
 
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         assertEquals(list, Collections.emptyList());
     }
 
@@ -136,7 +132,7 @@ public class Assignment6Test {
         int[] given = {0, 1, 2, 3};
         int[] desired = {1, 2, 3, 0};
 
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         assertEquals(list, Arrays.asList(
                 new Move(1, 1, 0),
                 new Move(2, 2, 1),
@@ -149,7 +145,7 @@ public class Assignment6Test {
         int[] given = {1, 2, 3, 4, 5, 6, 0};
         int[] desired = {3, 1, 6, 2, 4, 5, 0};
 
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         // check we perform 7 moves
         assertEquals(list.size(), 7);
     }
@@ -187,7 +183,7 @@ public class Assignment6Test {
         int[] given = givenList.stream().mapToInt(i->i).toArray();
         int[] givenEx = given.clone();
         int[] desired = desiredList.stream().mapToInt(i->i).toArray();
-        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> list = rearrangeGreedy(given, desired);
         executeMoves(givenEx, list);
         
         assertArrayEquals(givenEx, desired);
@@ -207,43 +203,8 @@ public class Assignment6Test {
         int[] givenGreedy = given.clone();
         int[] desired = desiredList.stream().mapToInt(i -> i).toArray();
         List<Move> list = rearrange(given, desired);
-        List<Move> listGreedy = rearrangeGreedy(givenGreedy, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        List<Move> listGreedy = rearrangeGreedy(givenGreedy, desired);
 
         assert(list.size() >= listGreedy.size());
-    }
-
-    @Test
-    public void testStressCompareTimeAlmostInPlace() {
-        int[] given = new int[100000];
-        int[] desired = new int[100000];
-        for (int i = 0; i < 100000; i++) {
-            given[i] = i;
-            desired[i] = i;
-        }
-        desired[90000] = 90003;
-        desired[90001] = 90000;
-        desired[90002] = 90001;
-        desired[90003] = 90002;
-
-        // warm up cache to avoid one alg being handicapped by cache misses
-        rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
-
-        //measure
-        long start = System.nanoTime();
-        List<Move> movesCaseTraversal = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
-        long end = System.nanoTime();
-        long timeTraversalNano = end - start;
-
-        start = System.nanoTime();
-        List<Move> movesCaseSet = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
-        end = System.nanoTime();
-        long timeSetNano = end - start;
-
-        System.out.println(timeSetNano);
-        System.out.println(timeTraversalNano);
-
-        assert(movesCaseSet.size() <= movesCaseTraversal.size());
-        assert(timeSetNano <= timeTraversalNano);
-
     }
 }

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -7,8 +7,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Assignment6Test {
 
@@ -90,7 +93,7 @@ public class Assignment6Test {
         int[] given = {1, 2, 0, 3};
         int[] desired = {3, 1, 2, 0};
 
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         assertEquals(list, Arrays.asList(
                 new Move(2, 1, 2),
                 new Move(1, 0, 1),
@@ -103,7 +106,7 @@ public class Assignment6Test {
         int[] given = {1, 2, 0, 3};
         int[] desired = {0, 1, 3, 2};
         
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         assertEquals(list, Arrays.asList(
                 new Move(3, 3, 2),
                 new Move(2, 1, 3),
@@ -115,7 +118,7 @@ public class Assignment6Test {
         int[] given = {1, 2, 0, 3};
         int[] desired = {1, 2, 0, 3};
 
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         assertEquals(list, Collections.emptyList());
     }
 
@@ -124,7 +127,7 @@ public class Assignment6Test {
         int[] given = {};
         int[] desired = {};
 
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         assertEquals(list, Collections.emptyList());
     }
 
@@ -133,7 +136,7 @@ public class Assignment6Test {
         int[] given = {0, 1, 2, 3};
         int[] desired = {1, 2, 3, 0};
 
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         assertEquals(list, Arrays.asList(
                 new Move(1, 1, 0),
                 new Move(2, 2, 1),
@@ -146,7 +149,7 @@ public class Assignment6Test {
         int[] given = {1, 2, 3, 4, 5, 6, 0};
         int[] desired = {3, 1, 6, 2, 4, 5, 0};
 
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         // check we perform 7 moves
         assertEquals(list.size(), 7);
     }
@@ -184,7 +187,7 @@ public class Assignment6Test {
         int[] given = givenList.stream().mapToInt(i->i).toArray();
         int[] givenEx = given.clone();
         int[] desired = desiredList.stream().mapToInt(i->i).toArray();
-        List<Move> list = rearrangeGreedy(given, desired);
+        List<Move> list = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
         executeMoves(givenEx, list);
         
         assertArrayEquals(givenEx, desired);
@@ -204,8 +207,43 @@ public class Assignment6Test {
         int[] givenGreedy = given.clone();
         int[] desired = desiredList.stream().mapToInt(i -> i).toArray();
         List<Move> list = rearrange(given, desired);
-        List<Move> listGreedy = rearrangeGreedy(givenGreedy, desired);
+        List<Move> listGreedy = rearrangeGreedy(givenGreedy, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
 
         assert(list.size() >= listGreedy.size());
+    }
+
+    @Test
+    public void testStressCompareTimeAlmostInPlace() {
+        int[] given = new int[100000];
+        int[] desired = new int[100000];
+        for (int i = 0; i < 100000; i++) {
+            given[i] = i;
+            desired[i] = i;
+        }
+        desired[90000] = 90003;
+        desired[90001] = 90000;
+        desired[90002] = 90001;
+        desired[90003] = 90002;
+
+        // warm up cache to avoid one alg being handicapped by cache misses
+        rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
+
+        //measure
+        long start = System.nanoTime();
+        List<Move> movesCaseTraversal = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_TRAVERSAL);
+        long end = System.nanoTime();
+        long timeTraversalNano = end - start;
+
+        start = System.nanoTime();
+        List<Move> movesCaseSet = rearrangeGreedy(given, desired, Assignment6.GREEDY_ALG_TYPE.UNBLOCK_USING_SET);
+        end = System.nanoTime();
+        long timeSetNano = end - start;
+
+        System.out.println(timeSetNano);
+        System.out.println(timeTraversalNano);
+
+        assert(movesCaseSet.size() <= movesCaseTraversal.size());
+        assert(timeSetNano <= timeTraversalNano);
+
     }
 }

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -5,52 +5,69 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.elifguler.Assignment6.rearrange;
+import static com.elifguler.Assignment6.Move;
 import static org.junit.jupiter.api.Assertions.*;
 
-class Assignment6Test {
+public class Assignment6Test {
+    
     @Test
-    void rearrangeTestNormal() {
-        int[] given = {1,2,0,3};
-        int[] desired = {3,1,2,0};
+    public void rearrangeTestNormal() {
+        int[] given = {1, 2, 0, 3};
+        int[] desired = {3, 1, 2, 0};
 
-        List<List<Integer>> list = rearrange(given, desired);
+        List<Move> list = rearrange(given, desired);
         assertEquals(list, Arrays.asList(
-                Arrays.asList(0,2),
-                Arrays.asList(3,0),
-                Arrays.asList(1,3),
-                Arrays.asList(2,1),
-                Arrays.asList(3,2)
+                new Move(1, 0, 2),
+                new Move(3, 3, 0),
+                new Move(2, 1, 3),
+                new Move(1, 2, 1),
+                new Move(2, 3, 2)
         ));
     }
 
     @Test
-    void rearrangeTestArranged() {
-        int[] given = {1,2,0,3};
-        int[] desired = {1,2,0,3};
+    public void rearrangeTestMoveEMpty() {
+        int[] given = {1, 2, 0, 3};
+        int[] desired = {0, 1, 3, 2};
+        
+        List<Move> list = rearrange(given, desired);
+        assertEquals(list, Arrays.asList(
+                new Move(2, 1, 2),
+                new Move(1, 0, 1),
+                new Move(2, 2, 0),
+                new Move(3, 3, 2),
+                new Move(2, 0, 3)));
+    }
+    
+    @Test
+    public void rearrangeTestArranged() {
+        int[] given = {1, 2, 0, 3};
+        int[] desired = {1, 2, 0, 3};
 
-        List<List<Integer>> list = rearrange(given, desired);
+        List<Move> list = rearrange(given, desired);
         assertEquals(list, Collections.emptyList());
     }
 
     @Test
-    void rearrangeTestEmpty() {
+    public void rearrangeTestEmpty() {
         int[] given = {};
         int[] desired = {};
 
-        List<List<Integer>> list = rearrange(given, desired);
+        List<Move> list = rearrange(given, desired);
         assertEquals(list, Collections.emptyList());
     }
 
     @Test
-    void rearrangeTestShift() {
-        int[] given = {0,1,2,3};
-        int[] desired = {1,2,3,0};
+    public void rearrangeTestShift() {
+        int[] given = {0, 1, 2, 3};
+        int[] desired = {1, 2, 3, 0};
 
-        List<List<Integer>> list = rearrange(given, desired);
+        List<Move> list = rearrange(given, desired);
         assertEquals(list, Arrays.asList(
-                Arrays.asList(1,0),
-                Arrays.asList(2,1),
-                Arrays.asList(3,2)
+                new Move(1, 1, 0),
+                new Move(2, 2, 1),
+                new Move(3, 3, 2)
         ));
     }
+    
 }

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -1,16 +1,18 @@
 package assignment6;
 
+import org.junit.jupiter.api.Test;
+
 import static assignment6.Assignment6.printListOfMoves;
 import static assignment6.Assignment6.rearrange;
 import static assignment6.Assignment6.rearrangeGreedy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class Assignment6Test {
-    
+
     @Test
     public void rearrangeTestNormal() {
         int[] given = {1, 2, 0, 3};
@@ -77,6 +79,9 @@ public class Assignment6Test {
         int[] desired = {3, 1, 2, 0};
 
         List<Move> list = rearrangeGreedy(given, desired);
+
+        printListOfMoves(list);
+
         assertEquals(list, Arrays.asList(
                 new Move(2, 1, 2),
                 new Move(1, 0, 1),
@@ -125,6 +130,16 @@ public class Assignment6Test {
                 new Move(2, 2, 1),
                 new Move(3, 3, 2)
         ));
+    }
+
+    @Test
+    public void rearrangeGreedyLongArray() {
+        int[] given = {1, 2, 3, 4, 5, 6, 0};
+        int[] desired = {3, 1, 6, 2, 4, 5, 0};
+
+        List<Move> list = rearrangeGreedy(given, desired);
+        // check we perform 7 moves
+        assertEquals(list.size(), 7);
     }
     
 }

--- a/Assignment6Test.java
+++ b/Assignment6Test.java
@@ -1,12 +1,13 @@
-import org.junit.jupiter.api.Test;
+package assignment6;
 
+import static assignment6.Assignment6.printListOfMoves;
+import static assignment6.Assignment6.rearrange;
+import static assignment6.Assignment6.rearrangeGreedy;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static com.elifguler.Assignment6.rearrange;
-import static com.elifguler.Assignment6.Move;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class Assignment6Test {
     
@@ -26,7 +27,7 @@ public class Assignment6Test {
     }
 
     @Test
-    public void rearrangeTestMoveEMpty() {
+    public void rearrangeTestMoveEmpty() {
         int[] given = {1, 2, 0, 3};
         int[] desired = {0, 1, 3, 2};
         
@@ -63,6 +64,62 @@ public class Assignment6Test {
         int[] desired = {1, 2, 3, 0};
 
         List<Move> list = rearrange(given, desired);
+        assertEquals(list, Arrays.asList(
+                new Move(1, 1, 0),
+                new Move(2, 2, 1),
+                new Move(3, 3, 2)
+        ));
+    }
+    
+    @Test
+    public void rearrangeGreedyTestNormal() {
+        int[] given = {1, 2, 0, 3};
+        int[] desired = {3, 1, 2, 0};
+
+        List<Move> list = rearrangeGreedy(given, desired);
+        assertEquals(list, Arrays.asList(
+                new Move(2, 1, 2),
+                new Move(1, 0, 1),
+                new Move(3, 3, 0)
+        ));
+    }
+
+    @Test
+    public void rearrangeGreedyTestMoveEmpty() {
+        int[] given = {1, 2, 0, 3};
+        int[] desired = {0, 1, 3, 2};
+        
+        List<Move> list = rearrangeGreedy(given, desired);
+        assertEquals(list, Arrays.asList(
+                new Move(3, 3, 2),
+                new Move(2, 1, 3),
+                new Move(1, 0, 1)));
+    }
+    
+    @Test
+    public void rearrangeGreedyTestArranged() {
+        int[] given = {1, 2, 0, 3};
+        int[] desired = {1, 2, 0, 3};
+
+        List<Move> list = rearrangeGreedy(given, desired);
+        assertEquals(list, Collections.emptyList());
+    }
+
+    @Test
+    public void rearrangeGreedyTestEmpty() {
+        int[] given = {};
+        int[] desired = {};
+
+        List<Move> list = rearrangeGreedy(given, desired);
+        assertEquals(list, Collections.emptyList());
+    }
+
+    @Test
+    public void rearrangeGreedyTestShift() {
+        int[] given = {0, 1, 2, 3};
+        int[] desired = {1, 2, 3, 0};
+
+        List<Move> list = rearrangeGreedy(given, desired);
         assertEquals(list, Arrays.asList(
                 new Move(1, 1, 0),
                 new Move(2, 2, 1),

--- a/Move.java
+++ b/Move.java
@@ -1,0 +1,43 @@
+package assignment6;
+
+public class Move {
+    
+    private final int from;
+    private final int to;
+    private final int car;
+    
+    public Move(int car, int from, int to) {
+        this.car = car;
+        this.from = from;
+        this.to = to;
+    }
+    
+    public int getCar() {
+        return this.car;
+    }
+    
+    public int getFrom() {
+        return this.from;
+    }
+    
+    public int getTo() {
+        return this.to;
+    }
+    
+    @Override
+    public String toString() {
+        return ("Car no. " + this.car + " moved from parking space " + this.from + " to " + this.to + ".");
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Move) {
+        Move m = (Move)o;
+            return (this.getCar() == m.getCar() &&
+                    this.getFrom() == m.getFrom() &&
+                    this.getTo() == m.getTo());
+        }
+        return false;
+    }
+    
+}


### PR DESCRIPTION
It seems that the running time in nanoseconds of greedy algorithm using traversal (which we thought is O(n^2)) is faster than the greedy algorithm using a set of misplaced cars. That's contrary to what we expected. The test name is **testStressCompareTimeAlmostInPlace()**. Perhaps I'm missing smth?